### PR TITLE
CTT-100: fix user login after registration

### DIFF
--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -22,6 +22,7 @@ class User(BaseModel):
             self.passwd, str
         ), "User password must be str, has the password been set?"
         assert isinstance(value, str), "Provided password must be str."
+        # import pdb; pdb.set_trace()
         return self.passwd == self.get_password_hash(value)
 
     def get_hashed_password(self) -> str:
@@ -31,10 +32,11 @@ class User(BaseModel):
         return self.get_password_hash(self.passwd)
 
     def get_password_hash(self, password: str) -> str:
+        assert password is not None, 'password must not be None.'
         passwd = hashlib.pbkdf2_hmac(
             'sha256',
             password.encode(),
-            str(self.id).encode().zfill(32),
+            '5up3rS3c|23T'.encode().zfill(32),
             100000,
             dklen=128,
         )

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -22,7 +22,6 @@ class User(BaseModel):
             self.passwd, str
         ), "User password must be str, has the password been set?"
         assert isinstance(value, str), "Provided password must be str."
-        # import pdb; pdb.set_trace()
         return self.passwd == self.get_password_hash(value)
 
     def get_hashed_password(self) -> str:


### PR DESCRIPTION
Hi, 

The reason the login does not work is because originally I wanted to hash every password with something unique, so I planned to use the userId to hash the password as a temp solution.

The problem with this approach is that when registering a new user, I need to get the hashed value BEFORE creating the user, so there is no userId yet at the time I am originally creating the password hash.  

Instead of re-writing the registration, I implemented a workaround to use the same string to hash every password, which is fine for the purposes of this project.